### PR TITLE
Update firmware.md

### DIFF
--- a/docs/firmware.md
+++ b/docs/firmware.md
@@ -65,8 +65,7 @@ unlock the vendor modes and configuration bits.
 
 There are several features configurable via the `patch-airsense`
 script, some of which are simple binary patches and some of which
-require a 32-bit ARM toolchain. Set them as desired per the
-documentation [here](../info/firmware-docs).
+require a 32-bit ARM toolchain.
 
 The script might fail if the hashes of your extracted firmware do not
 match the one that it expects (currently `SX567-0401`). If you have a


### PR DESCRIPTION
Hi Asmageddon, 
I noticed this page is missing (on the original airbreak repo too). If you're accepting pull requests I'd be happy to provide some feedback after having just used airbreak-plus.

Secondly, I noticed the patch is missing some menu items in ST and T mode that I need (Resp Rate, Target Pt. Rate, etc). I have my own legitimate copy of the ST firmware that I dumped myself from my machine (it's the Australian version of the AirCurve 10 - Lumis 150 ST), but when I try to flash it the device gets stuck in a boot loop. Would you by any chance be willing to help me look at the logs and understand what the issue is?
Thank you.