### PR TITLE
change anti-tamper patch logic to skip calculating checksums only

### DIFF
--- a/patch-airsense
+++ b/patch-airsense
@@ -69,16 +69,37 @@ check_hash() {
 cp "$IN" "$OUT" || die "$OUT: copy failed"
 
 patch_tamper() {
-    # i've never seen bootloader version other than SX577-0200, so no point in doing safety checks
+    # All firmware versions across airsense and aircurve devices have BID=SX577-0200
+    # But Lumis running on SX585-0200 is unique
 
-    echo -n "Patching firmware integrity checks... "
-    # Skip BLX check
-    printf '\x01\x20\xc0\x46' | patch 0x310e && echo -n "BLX ok " || die "patch failed (BLX)"
-    # Skip CCX check
-    printf '\x00\x20\xc0\x46' | patch 0x313e && echo -n "CCX ok " || die "patch failed (CCX)"
-    # Skip CDX check
-    printf '\x00\x20\xc0\x46' | patch 0x3130 && echo -n "CDX ok " || die "patch failed (CDX)"
-    echo
+    local version=$(dd if="$OUT" bs=1 skip=$((0x3f80)) count=10 2>/dev/null)
+
+    case "$version" in
+        "SX577-0200")
+            echo -n "Patching firmware integrity checks... "
+            # Skip BLX check
+            printf '\x01\x20\xc0\x46' | patch 0x310e && echo -n "BLX ok " || die "patch failed (BLX)"
+            # Skip CCX check
+            printf '\x00\x20\xc0\x46' | patch 0x313e && echo -n "CCX ok " || die "patch failed (CCX)"
+            # Skip CDX check
+            printf '\x00\x20\xc0\x46' | patch 0x3130 && echo -n "CDX ok " || die "patch failed (CDX)"
+            echo
+            ;;
+        "SX585-0200")
+            # Skip BLX check
+            printf '\x01\x20\xc0\x46' | patch 0x316e && echo -n "BLX ok " || die "patch failed (BLX)"
+            # Skip CCX check
+            printf '\x00\x20\xc0\x46' | patch 0x319e && echo -n "CCX ok " || die "patch failed (CCX)"
+            # Skip CDX check
+            printf '\x00\x20\xc0\x46' | patch 0x3190 && echo -n "CDX ok " || die "patch failed (CDX)"
+            echo
+            ;;
+        *)
+            die "Unknown bootloader version: '$version'"
+            # or try previous method if you know what you're doing
+            # printf '\xc0\x46' | patch 0xf0 || die "startup patch failed"
+            ;;
+    esac
 }
 
 patch_strings() {

--- a/patch-airsense
+++ b/patch-airsense
@@ -69,9 +69,16 @@ check_hash() {
 cp "$IN" "$OUT" || die "$OUT: copy failed"
 
 patch_tamper() {
-	# patch the jump instruction that checks for tamper
-	printf '\xc0\x46' | patch 0xf0 \
-	|| die "startup patch failed"
+    # i've never seen bootloader version other than SX577-0200, so no point in doing safety checks
+
+    echo -n "Patching firmware integrity checks... "
+    # Skip BLX check
+    printf '\x01\x20\xc0\x46' | patch 0x310e && echo -n "BLX ok " || die "patch failed (BLX)"
+    # Skip CCX check
+    printf '\x00\x20\xc0\x46' | patch 0x313e && echo -n "CCX ok " || die "patch failed (CCX)"
+    # Skip CDX check
+    printf '\x00\x20\xc0\x46' | patch 0x3130 && echo -n "CDX ok " || die "patch failed (CDX)"
+    echo
 }
 
 patch_strings() {

--- a/python/patch-airsense.py
+++ b/python/patch-airsense.py
@@ -261,7 +261,9 @@ class ASFirmwarePatches(object):
     def bypass_startcheck(self):
         #Start-up check for CRC etc, bypass it to avoid (might not be needed)
         if self.asf.hash == self.known_units[0].hash:
-            asf.patch(b'\xc0\x46', 0xF0, clobber=True)
+            asf.patch(b'\x01\x20\xc0\x46', 0x310e, clobber=True) # BLX
+            asf.patch(b'\x00\x20\xc0\x46', 0x313e, clobber=True) # CCX
+            asf.patch(b'\x00\x20\xc0\x46', 0x3130, clobber=True) # CDX
         else:
             raise IOError("Unknown hash: %s"%self.asf.hash)
             

--- a/python/patch-airsense.py
+++ b/python/patch-airsense.py
@@ -260,12 +260,20 @@ class ASFirmwarePatches(object):
 
     def bypass_startcheck(self):
         #Start-up check for CRC etc, bypass it to avoid (might not be needed)
-        if self.asf.hash == self.known_units[0].hash:
+        loader = self.asf.str_loader_ver.strip('\x00')
+
+        if loader.startswith('SX577-0200'):
+            # AirSense / AirCurve variant
             asf.patch(b'\x01\x20\xc0\x46', 0x310e, clobber=True) # BLX
             asf.patch(b'\x00\x20\xc0\x46', 0x313e, clobber=True) # CCX
             asf.patch(b'\x00\x20\xc0\x46', 0x3130, clobber=True) # CDX
+        elif loader.startswith('SX585-0200'):
+            # Lumis
+            self.asf.patch(b'\x01\x20\xc0\x46', 0x316e, clobber=True) # BLX
+            self.asf.patch(b'\x00\x20\xc0\x46', 0x319e, clobber=True) # CCX
+            self.asf.patch(b'\x00\x20\xc0\x46', 0x3190, clobber=True) # CDX
         else:
-            raise IOError("Unknown hash: %s"%self.asf.hash)
+            raise IOError("Unknown bootloader version: '%s' (hash: %s)" % (loader, self.asf.hash))
             
     def change_text(self):
         if self.asf.hash == self.known_units[0].hash:


### PR DESCRIPTION
...not bootloader stage entirely ;)

this is required to allow flashing over UART on airbreak firmware.
Previous implementation caused bootloader to jump directly to CDX code
<img width="694" height="454" alt="image" src="https://github.com/user-attachments/assets/935fcb96-9b2f-4589-8efd-2e470c31013e" />

(While patching three bytes would be enough to achieve the same effect in a cleaner way, I went with the longer approach, figuring that since we don’t care about the checksum value, there’s no point wasting time calculating it.)